### PR TITLE
Use Integer in lieu of Fixnum in order to remove deprecation warnings

### DIFF
--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -127,7 +127,7 @@ module IceCube
     def self.sym_to_month(sym)
       MONTHS.fetch(sym) do |k|
         MONTHS.values.detect { |i| i.to_s == k.to_s } or
-        raise ArgumentError, "Expecting Fixnum or Symbol value for month. " \
+        raise ArgumentError, "Expecting Integer or Symbol value for month. " \
                              "No such month: #{k.inspect}"
       end
     end
@@ -137,7 +137,7 @@ module IceCube
     def self.sym_to_wday(sym)
       DAYS.fetch(sym) do |k|
         DAYS.values.detect { |i| i.to_s == k.to_s } or
-        raise ArgumentError, "Expecting Fixnum or Symbol value for weekday. " \
+        raise ArgumentError, "Expecting Integer or Symbol value for weekday. " \
                              "No such weekday: #{k.inspect}"
       end
     end
@@ -147,7 +147,7 @@ module IceCube
     def self.wday_to_sym(wday)
       return sym = wday if DAYS.keys.include? wday
       DAYS.invert.fetch(wday) do |i|
-        raise ArgumentError, "Expecting Fixnum value for weekday. " \
+        raise ArgumentError, "Expecting Integer value for weekday. " \
                              "No such wday number: #{i.inspect}"
       end
     end

--- a/lib/ice_cube/validations/count.rb
+++ b/lib/ice_cube/validations/count.rb
@@ -8,8 +8,8 @@ module IceCube
     end
 
     def count(max)
-      unless max.nil? || max.is_a?(Fixnum)
-        raise ArgumentError, "Expecting Fixnum or nil value for count, got #{max.inspect}"
+      unless max.nil? || max.is_a?(Integer)
+        raise ArgumentError, "Expecting Integer or nil value for count, got #{max.inspect}"
       end
       @count = max
       replace_validations_for(:count, max && [Validation.new(max, self)])

--- a/lib/ice_cube/validations/day.rb
+++ b/lib/ice_cube/validations/day.rb
@@ -6,8 +6,8 @@ module IceCube
 
     def day(*days)
       days.flatten.each do |day|
-        unless day.is_a?(Fixnum) || day.is_a?(Symbol)
-          raise ArgumentError, "expecting Fixnum or Symbol value for day, got #{day.inspect}"
+        unless day.is_a?(Integer) || day.is_a?(Symbol)
+          raise ArgumentError, "expecting Integer or Symbol value for day, got #{day.inspect}"
         end
         day = TimeUtil.sym_to_wday(day)
         validations_for(:day) << Validation.new(day)

--- a/lib/ice_cube/validations/day_of_month.rb
+++ b/lib/ice_cube/validations/day_of_month.rb
@@ -4,8 +4,8 @@ module IceCube
 
     def day_of_month(*days)
       days.flatten.each do |day|
-        unless day.is_a?(Fixnum)
-          raise ArgumentError, "expecting Fixnum value for day, got #{day.inspect}"
+        unless day.is_a?(Integer)
+          raise ArgumentError, "expecting Integer value for day, got #{day.inspect}"
         end
         validations_for(:day_of_month) << Validation.new(day)
       end

--- a/lib/ice_cube/validations/day_of_year.rb
+++ b/lib/ice_cube/validations/day_of_year.rb
@@ -4,8 +4,8 @@ module IceCube
 
     def day_of_year(*days)
       days.flatten.each do |day|
-        unless day.is_a?(Fixnum)
-          raise ArgumentError, "expecting Fixnum value for day, got #{day.inspect}"
+        unless day.is_a?(Integer)
+          raise ArgumentError, "expecting Integer value for day, got #{day.inspect}"
         end
         validations_for(:day_of_year) << Validation.new(day)
       end

--- a/lib/ice_cube/validations/hour_of_day.rb
+++ b/lib/ice_cube/validations/hour_of_day.rb
@@ -5,8 +5,8 @@ module IceCube
     # Add hour of day validations
     def hour_of_day(*hours)
       hours.flatten.each do |hour|
-        unless hour.is_a?(Fixnum)
-          raise ArgumentError, "expecting Fixnum value for hour, got #{hour.inspect}"
+        unless hour.is_a?(Integer)
+          raise ArgumentError, "expecting Integer value for hour, got #{hour.inspect}"
         end
         validations_for(:hour_of_day) << Validation.new(hour)
       end

--- a/lib/ice_cube/validations/minute_of_hour.rb
+++ b/lib/ice_cube/validations/minute_of_hour.rb
@@ -4,8 +4,8 @@ module IceCube
 
     def minute_of_hour(*minutes)
       minutes.flatten.each do |minute|
-        unless minute.is_a?(Fixnum)
-          raise ArgumentError, "expecting Fixnum value for minute, got #{minute.inspect}"
+        unless minute.is_a?(Integer)
+          raise ArgumentError, "expecting Integer value for minute, got #{minute.inspect}"
         end
         validations_for(:minute_of_hour) << Validation.new(minute)
       end

--- a/lib/ice_cube/validations/month_of_year.rb
+++ b/lib/ice_cube/validations/month_of_year.rb
@@ -4,8 +4,8 @@ module IceCube
 
     def month_of_year(*months)
       months.flatten.each do |month|
-        unless month.is_a?(Fixnum) || month.is_a?(Symbol)
-          raise ArgumentError, "expecting Fixnum or Symbol value for month, got #{month.inspect}"
+        unless month.is_a?(Integer) || month.is_a?(Symbol)
+          raise ArgumentError, "expecting Integer or Symbol value for month, got #{month.inspect}"
         end
         month = TimeUtil.sym_to_month(month)
         validations_for(:month_of_year) << Validation.new(month)

--- a/lib/ice_cube/validations/second_of_minute.rb
+++ b/lib/ice_cube/validations/second_of_minute.rb
@@ -4,8 +4,8 @@ module IceCube
 
     def second_of_minute(*seconds)
       seconds.flatten.each do |second|
-      unless second.is_a?(Fixnum)
-        raise ArgumentError, "Expecting Fixnum value for second, got #{second.inspect}"
+      unless second.is_a?(Integer)
+        raise ArgumentError, "Expecting Integer value for second, got #{second.inspect}"
       end
         validations_for(:second_of_minute) << Validation.new(second)
       end


### PR DESCRIPTION
Ruby 2.4 unified Fixnum and Bignum into integer https://bugs.ruby-lang.org/issues/12005.
This chane replaces usages of Fixnum with Integer to remove deprecation warnings on Ruby 2.4+.